### PR TITLE
Fix package wrapper not copying the original item size (#2197)

### DIFF
--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -248,6 +248,7 @@
 					user.client.screen -= O
 			P.wrapped = O
 			O.forceMove(P)
+			P.w_class = O.w_class
 			var/i = round(O.w_class)
 			if(i in list(1,2,3,4,5))
 				P.icon_state = "deliverycrate[i]"


### PR DESCRIPTION
This will stop all dirty powergamers from using this to stuff shit they should be able to into bags.

* Please describe the intent of your changes in a clear fashion.
* Please make sure that, in the case of icon or mapping changes, you include images of these changes in the PR's description.
